### PR TITLE
Feat/input native autocomplete prop

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -26,6 +26,7 @@ export interface Props extends InputHTMLAttributes<HTMLInputElement> {
   width?: any
   maxWidth?: any
   mask?: string
+  nativeAutoComplete?: 'on' | 'disabled'
 }
 
 export const Input: React.FC<Props> = ({
@@ -43,6 +44,7 @@ export const Input: React.FC<Props> = ({
   mask,
   onChange,
   disabled,
+  nativeAutoComplete = 'on',
   ...props
 }) => {
   if (variant === 'outlined') {
@@ -66,6 +68,7 @@ export const Input: React.FC<Props> = ({
               data-testid='input-container'
               placeholder={placeholder}
               disabled={disabled}
+              nativeAutoComplete={nativeAutoComplete}
               {...props}
               {...inputProps}
             />
@@ -88,6 +91,7 @@ export const Input: React.FC<Props> = ({
         placeholder={placeholder}
         onChange={onChange}
         disabled={disabled}
+        nativeAutoComplete={nativeAutoComplete}
         {...props}
       />
     )
@@ -104,6 +108,7 @@ export const Input: React.FC<Props> = ({
         placeholder={placeholder}
         onChange={onChange}
         data-testid='input-container'
+        nativeAutoComplete={nativeAutoComplete}
         {...props}
       />
     )
@@ -128,6 +133,7 @@ export const Input: React.FC<Props> = ({
             prefix={prefix}
             placeholder={placeholder}
             data-testid='input-container'
+            nativeAutoComplete={nativeAutoComplete}
             {...inputProps}
             {...props}
           />
@@ -150,6 +156,7 @@ export const Input: React.FC<Props> = ({
       onChange={onChange}
       data-testid='input-container'
       disabled={disabled}
+      nativeAutoComplete={nativeAutoComplete}
       {...props}
     />
   )
@@ -175,5 +182,6 @@ Input.propTypes = {
   maxWidth: PropTypes.any,
   mask: PropTypes.string,
   onChange: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  nativeAutoComplete: PropTypes.oneOf(['on', 'disabled'])
 }

--- a/src/components/Input/InputNeutral.tsx
+++ b/src/components/Input/InputNeutral.tsx
@@ -28,6 +28,7 @@ export interface Props extends InputHTMLAttributes<HTMLInputElement> {
   border?: any
   width?: any
   maxWidth?: any
+  nativeAutoComplete?: 'on' | 'disabled'
 }
 
 const InputStyled = styled.input<Props>`
@@ -105,8 +106,20 @@ const InputPrefixed = styled.input<Props>`
   margin-left: 16px;
 `
 
-const Input: React.FC<Props> = ({ inputRef, value, ...props }) => {
-  return <InputStyled value={value} ref={inputRef} {...props} />
+const Input: React.FC<Props> = ({
+  inputRef,
+  value,
+  nativeAutoComplete,
+  ...props
+}) => {
+  return (
+    <InputStyled
+      value={value}
+      ref={inputRef}
+      autoComplete={nativeAutoComplete}
+      {...props}
+    />
+  )
 }
 
 export const InputNeutral: React.FC<Props> = ({
@@ -120,6 +133,7 @@ export const InputNeutral: React.FC<Props> = ({
   value,
   placeholder,
   containerProps,
+  nativeAutoComplete,
   ...props
 }) => {
   const [inputSelected, setInputSelected] = useState(false)
@@ -148,6 +162,7 @@ export const InputNeutral: React.FC<Props> = ({
             placeholder={placeholder}
             type={type}
             value={value}
+            autoComplete={nativeAutoComplete}
             {...props}
           />
           {sufix}
@@ -173,6 +188,7 @@ export const InputNeutral: React.FC<Props> = ({
             placeholder={placeholder}
             type={type}
             value={value}
+            autoComplete={nativeAutoComplete}
             {...props}
           />
         </ContainerSufix>
@@ -197,6 +213,7 @@ export const InputNeutral: React.FC<Props> = ({
             placeholder={placeholder}
             type={passwordVisible ? 'text' : 'password'}
             value={value}
+            autoComplete={nativeAutoComplete}
           />
           <Button
             palette='primary'
@@ -229,6 +246,7 @@ export const InputNeutral: React.FC<Props> = ({
         value={value}
         {...props}
         data-testid='input'
+        nativeAutoComplete={nativeAutoComplete}
       />
 
       {errorForm && <InputErrorMessage errorMessage={errorMessage} />}
@@ -238,7 +256,8 @@ export const InputNeutral: React.FC<Props> = ({
 
 Input.propTypes = {
   inputRef: PropTypes.any,
-  value: PropTypes.string
+  value: PropTypes.string,
+  nativeAutoComplete: PropTypes.oneOf(['on', 'disabled'])
 }
 
 InputNeutral.propTypes = {
@@ -253,6 +272,7 @@ InputNeutral.propTypes = {
   placeholder: PropTypes.string,
   containerProps: PropTypes.object,
   boxProps: PropTypes.object,
+  nativeAutoComplete: PropTypes.oneOf(['on', 'disabled']),
 
   backgroundColor: PropTypes.any,
   border: PropTypes.any,

--- a/src/components/Input/InputOutlined.tsx
+++ b/src/components/Input/InputOutlined.tsx
@@ -35,6 +35,8 @@ export interface Props
 
   maxWidth?: number | string
   backgroundColor?: number | string
+
+  nativeAutoComplete?: 'on' | 'disabled'
 }
 
 const Container = styled(Box)`
@@ -186,6 +188,7 @@ export const InputOutlined: React.FC<Props> = ({
   marginLeft,
   containerProps,
   disabled,
+  nativeAutoComplete,
   ...props
 }) => {
   const [showPassword, setShowPassword] = useState(false)
@@ -219,6 +222,7 @@ export const InputOutlined: React.FC<Props> = ({
             name={name}
             disabled={disabled}
             data-testid='input'
+            autoComplete={nativeAutoComplete}
           />
           {label && <Text data-testid='input-label'>{label}</Text>}
 
@@ -260,8 +264,8 @@ export const InputOutlined: React.FC<Props> = ({
             ref={inputRef}
             name={name}
             disabled={disabled}
-            autoComplete='disabled'
             data-testid='input'
+            autoComplete={nativeAutoComplete}
           />
           {label && <Text data-testid='input-label'>{label}</Text>}
 
@@ -293,8 +297,8 @@ export const InputOutlined: React.FC<Props> = ({
           type={type}
           ref={inputRef}
           disabled={disabled}
-          autoComplete='disabled'
           data-testid='input'
+          autoComplete={nativeAutoComplete}
         />
         {label && <Text data-testid='input-label'>{label}</Text>}
       </LabelStyled>
@@ -319,5 +323,6 @@ InputOutlined.propTypes = {
   marginLeft: PropTypes.any,
   marginRight: PropTypes.any,
   containerProps: PropTypes.any,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  nativeAutoComplete: PropTypes.oneOf(['on', 'disabled'])
 }

--- a/src/components/Input/InputOutlined.tsx
+++ b/src/components/Input/InputOutlined.tsx
@@ -260,6 +260,7 @@ export const InputOutlined: React.FC<Props> = ({
             ref={inputRef}
             name={name}
             disabled={disabled}
+            autoComplete='disabled'
             data-testid='input'
           />
           {label && <Text data-testid='input-label'>{label}</Text>}

--- a/src/components/Input/InputTags.tsx
+++ b/src/components/Input/InputTags.tsx
@@ -24,6 +24,7 @@ export interface Props {
   border?: any
   width?: any
   maxWidth?: any
+  nativeAutoComplete?: 'on' | 'disabled'
 }
 
 const InputStyled = styled.input<Props>`
@@ -87,6 +88,7 @@ export const InputTags: React.FC<Props> = ({
   maxWidth,
   value,
   onChange,
+  nativeAutoComplete,
   ...props
 }) => {
   const [inputValue, setInputValue] = useState<string>('')
@@ -151,6 +153,7 @@ export const InputTags: React.FC<Props> = ({
         type={type}
         onChange={e => setInputValue(e.target.value)}
         value={inputValue}
+        autoComplete={nativeAutoComplete}
         {...boxStyled}
       />
 
@@ -171,5 +174,6 @@ InputTags.propTypes = {
   backgroundColor: PropTypes.any,
   border: PropTypes.any,
   width: PropTypes.any,
-  maxWidth: PropTypes.any
+  maxWidth: PropTypes.any,
+  nativeAutoComplete: PropTypes.oneOf(['on', 'disabled'])
 }

--- a/src/components/MultiSelect/MultiSelectFetchable.tsx
+++ b/src/components/MultiSelect/MultiSelectFetchable.tsx
@@ -317,6 +317,7 @@ export const MultiSelectFetchable: React.FC<Props> = ({
                   }
                 })
               )}
+              autoComplete='disabled'
             />
           </Flex>
 

--- a/src/components/MultiSelect/MultiSelectStatic.tsx
+++ b/src/components/MultiSelect/MultiSelectStatic.tsx
@@ -318,6 +318,7 @@ export const MultiSelectStatic: React.FC<Props> = ({
                 }
               })
             )}
+            autoComplete='disabled'
           />
         </ContainerInput>
 

--- a/src/components/Select/SelectFetchable.tsx
+++ b/src/components/Select/SelectFetchable.tsx
@@ -195,6 +195,7 @@ export const SelectFetchable: React.FC<Props> = ({
           readOnly={!autoComplete}
           prefix={prefix}
           placeholder={placeholder}
+          nativeAutoComplete='disabled'
           {...boxStyled}
         />
         {isLoading && (

--- a/src/components/Select/SelectStatic.tsx
+++ b/src/components/Select/SelectStatic.tsx
@@ -209,6 +209,7 @@ export const SelectStatic: React.FC<Props> = ({
               openMenu()
             }
           })}
+          nativeAutoComplete='disabled'
           {...boxStyled}
         />
         {isLoading && (


### PR DESCRIPTION
Adiciona prop `nativeAutoComplete` nos Inputs e desativa o autocomplete do browser nas variações de Selects e Multiselects.