### PR TITLE
fix(input-outlined): transparent style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiq-design-system",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "main": "core/index.js",
   "repository": "git@github.com:aiqfome/aiq-design-system.git",
   "license": "MIT",

--- a/src/components/Input/InputOutlined.tsx
+++ b/src/components/Input/InputOutlined.tsx
@@ -101,7 +101,8 @@ const LabelStyled = styled.label<Props>`
 
     &:focus {
       border-color: ${({ theme }) => theme.colors.primary};
-      border-top-color: transparent;
+      border-top-color: ${({ theme, label }) =>
+        label ? 'transparent' : theme.colors.primary};
       box-shadow: inset 1px 0 ${({ theme }) => theme.colors.primaryLight},
         inset -1px 0 ${({ theme }) => theme.colors.primaryLight},
         inset 0 -1px ${({ theme }) => theme.colors.primaryLight};
@@ -277,7 +278,9 @@ export const InputOutlined = React.forwardRef<HTMLInputElement, Props>(
             />
             {label && <Text data-testid='input-label'>{label}</Text>}
 
-            <Box className='sufix'><Loading marginLeft={5}/></Box>
+            <Box className='sufix'>
+              <Loading marginLeft={5} />
+            </Box>
           </LabelStyled>
 
           {errorForm && <InputErrorMessage errorMessage={errorMessage} />}


### PR DESCRIPTION
o input outlined sem label fica com a borda de cima transparente quando em "focus"

![image](https://github.com/aiqfome/aiq-design-system/assets/72887949/38cc95f3-38f1-4998-b62e-5f5896044930)

